### PR TITLE
Add ability to update elections table

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -14,7 +14,7 @@ timeout: 200
 storage_dir: /path/to/storage/GA
 csv_name: STATEWIDE.csv
 db: ga_db
-table: jan5runoff
+table: 01_05_2021
 ga_files: /path/to/ga/files
 
 [NC]

--- a/db/ingest/download-GA.py
+++ b/db/ingest/download-GA.py
@@ -13,7 +13,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.select import Select
 
 from schema import schema_table, ga_load
-from elections import elections_table, elections_load
+from elections import elections_table, update_proc_date
 
 config = configparser.ConfigParser()
 if not config.read('config.ini'):
@@ -127,15 +127,7 @@ query = elections_table()
 cursor.execute(query)
 mydb.commit()
 
-# update the value of election last processed date
-today = date.today()
-test_proc_date = today.strftime("%m/%d/%Y")
-
-entry = {
-  "election_dt": config['GA']['table'], 
-  "proc_date": test_proc_date
-}
-
-query = elections_load(entry)
+# update processed date
+query = update_proc_date(config['GA']['table'])
 cursor.execute(query)
 mydb.commit()

--- a/db/ingest/download-GA.py
+++ b/db/ingest/download-GA.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.select import Select
 
 from schema import schema_table, ga_load
+from elections import elections_table, elections_load
 
 config = configparser.ConfigParser()
 if not config.read('config.ini'):
@@ -119,3 +120,22 @@ mydb.commit()
 
 print('Database insertion executed.')
 print(f'Total time: {time.time() - start_time} seconds')
+
+print('Updating processed date.')
+# create the elections table
+query = elections_table()
+cursor.execute(query)
+mydb.commit()
+
+# update the value of election last processed date
+today = date.today()
+test_proc_date = today.strftime("%m/%d/%Y")
+
+entry = {
+  "election_dt": config['GA']['table'], 
+  "proc_date": test_proc_date
+}
+
+query = elections_load(entry)
+cursor.execute(query)
+mydb.commit()

--- a/db/ingest/download-NC.py
+++ b/db/ingest/download-NC.py
@@ -8,6 +8,7 @@ import time
 from datetime import date
 
 from schema import schema_table
+from elections import elections_table, elections_load
 
 config = configparser.ConfigParser()
 config.read('config.ini')
@@ -104,3 +105,23 @@ cursor.execute(query)
 mydb.commit()
 
 print('Database query executed.')
+
+print('Updating processed date.')
+
+# create the elections table
+query = elections_table()
+cursor.execute(query)
+mydb.commit()
+
+# update the value of election last processed date
+today = date.today()
+test_proc_date = today.strftime("%m/%d/%Y")
+
+entry = {
+  "election_dt": config['NC']['table'], 
+  "proc_date": test_proc_date
+}
+
+query = elections_load(entry)
+cursor.execute(query)
+mydb.commit()

--- a/db/ingest/download-NC.py
+++ b/db/ingest/download-NC.py
@@ -8,7 +8,7 @@ import time
 from datetime import date
 
 from schema import schema_table
-from elections import elections_table, elections_load
+from elections import elections_table, update_proc_date
 
 config = configparser.ConfigParser()
 config.read('config.ini')
@@ -113,15 +113,7 @@ query = elections_table()
 cursor.execute(query)
 mydb.commit()
 
-# update the value of election last processed date
-today = date.today()
-test_proc_date = today.strftime("%m/%d/%Y")
-
-entry = {
-  "election_dt": config['NC']['table'], 
-  "proc_date": test_proc_date
-}
-
-query = elections_load(entry)
+# update processed date
+query = update_proc_date(config['NC']['table'])
 cursor.execute(query)
 mydb.commit()

--- a/db/scripts/queries.py
+++ b/db/scripts/queries.py
@@ -99,10 +99,10 @@ def get_cured(table):
 	return f'''
 	SELECT
     acc.*
-	FROM 01_04_2021 as rej
+	FROM {table} as rej
 	INNER JOIN ( 
     SELECT *
-    FROM 01_04_2021
+    FROM {table}
     WHERE ballot_rtn_status='A') acc
 	ON acc.voter_reg_id = rej.voter_reg_id 
 	WHERE rej.ballot_rtn_status='R';

--- a/db/shared/elections.py
+++ b/db/shared/elections.py
@@ -1,0 +1,18 @@
+
+# creates election table
+def elections_table():
+    return f'''
+    CREATE TABLE IF NOT EXISTS elections (
+      election_dt             DATETIME,
+      proc_date               DATETIME,
+      PRIMARY KEY(election_dt)
+    );
+    '''
+
+# adds new entry for processed time
+def elections_load(entry):
+  return f'''
+  INSERT INTO elections (election_dt, proc_date) 
+  VALUES(STR_TO_DATE('{entry["election_dt"]}','%m_%d_%Y'),STR_TO_DATE("{entry["proc_date"]}",'%m/%d/%Y')) 
+  ON DUPLICATE KEY UPDATE proc_date = STR_TO_DATE("{entry["proc_date"]}",'%m/%d/%Y');
+  '''

--- a/db/shared/elections.py
+++ b/db/shared/elections.py
@@ -1,3 +1,15 @@
+from datetime import date
+
+def update_proc_date(election_dt):
+  # update the value of election last processed date
+  today = date.today().strftime("%m/%d/%Y")
+
+  entry = {
+    "election_dt": election_dt, 
+    "proc_date": today
+  }
+
+  return elections_load_new_entry(entry)
 
 # creates election table
 def elections_table():
@@ -10,7 +22,7 @@ def elections_table():
     '''
 
 # adds new entry for processed time
-def elections_load(entry):
+def elections_load_new_entry(entry):
   return f'''
   INSERT INTO elections (election_dt, proc_date) 
   VALUES(STR_TO_DATE('{entry["election_dt"]}','%m_%d_%Y'),STR_TO_DATE("{entry["proc_date"]}",'%m/%d/%Y')) 


### PR DESCRIPTION
This PR cleans up some older code to be more general and also updates last processed time in `elections` table for each DB whenever ingesting new data.